### PR TITLE
Reduce Docker image size (+ a few tweaks)

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[requires]
+python_version = "3.8"
+
+[packages]
+ase = "*"
+dlmontepython = "*"
+matplotlib = "*"
+numpy = "*"
+pandas = "*"
+PyYAML = "*"
+scipy = "*"

--- a/scripts/isotherm_runner.py
+++ b/scripts/isotherm_runner.py
@@ -38,7 +38,7 @@ with open('./CONTROL', 'w') as f:
 infile = 'Cu_BTC'
 
 print(infile)
-c2c.create_config_field(infile, input_directory='interface/', output_directory='./')
+c2c.create_config_field(infile, input_directory='interface/', output_directory='')
 
 # Set up the relevant TaskInterface object: which tells the low-level machinery in the 'task' package
 # which code will be used to perform the simulations, and how to perform various tasks specific to that

--- a/scripts/isotherm_runner.py
+++ b/scripts/isotherm_runner.py
@@ -38,7 +38,7 @@ with open('./CONTROL', 'w') as f:
 infile = 'Cu_BTC'
 
 print(infile)
-c2c.create_config_field(infile,input_directory='.', output_directory='')
+c2c.create_config_field(infile, input_directory='interface/', output_directory='./')
 
 # Set up the relevant TaskInterface object: which tells the low-level machinery in the 'task' package
 # which code will be used to perform the simulations, and how to perform various tasks specific to that
@@ -48,7 +48,7 @@ c2c.create_config_field(infile,input_directory='.', output_directory='')
 # below sets up a DL_MONTE-specific interface. Note that the interface must know the location of the 
 # DL_MONTE executable - which is specified as the argument to the DLMonteInterface constructor.
 
-interface = interface.DLMonteInterface("../../../DLMONTE-SRL.X")
+interface = interface.DLMonteInterface("/usr/local/bin/DLMONTE-SRL.X")
 
 # Set up a list of 'observables' to track and analyse. Observables must be Observable objects, and the nature
 # of Observable objects may vary between simulation codes. For DL_MONTE only observables corresponding to variables


### PR DESCRIPTION
In this PR, I made some minor changes to the `Dockerfile` so that the image size shrinks from 1.44 GB to 682 MB. It may be possible to shrink it further, but not without making some drastic changes to the base image, which would disable the use of `apt-get`. Most of what I did was taken from [here](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/).

The system libraries in the `Dockerfile` are now separated from the Python libraries in the `Pipfile`, for better portability and for allowing one to create a local Python environment for testing and development. Just remove `--system` when installing locally.

I am using `podman` instead of `docker` for ["reasons"](https://www.infoq.com/news/2021/09/docker-desktop-subscriptions/) but the commands for you should be roughly the same:
```Shell
podman build -t dlmonte  .
podman run -v $PWD/interface/:/run/interface/ dlmonte python isotherm_runner.py
```

The `podman run` comand above will map my laptop's `./interface` folder to the container's `/run/interface` folder where the CIF file resides. For that to work, I had to manually change the `create_config_field()` inputs, but many more folder-related changes will be necessary in the code for it to fully work. The changes I made only relate to the input folder, but the output files are still not being written to `/run/interface` and available from the host system (laptop).

Going forward, what I suggest is to instrument your code using [Argparse](https://docs.python.org/3/howto/argparse.html) to take the input and output folders from the command line, as in the example below
```Python
parser.add_argument('--InputFolder',
                    type=str,
                    action='store',
                    required=True,
                    metavar='INPUT_FOLDER',
                    help='Location of the framework CIF files.')
```